### PR TITLE
Build support

### DIFF
--- a/Assets/IATK/Scripts/Controller/AbstractVisualisation.cs
+++ b/Assets/IATK/Scripts/Controller/AbstractVisualisation.cs
@@ -81,7 +81,7 @@ namespace IATK
         public CreationConfiguration creationConfiguration;
 
         [HideInInspector]
-        public string serializedObjectPath = "Resources/SerializedFields"; // moved to Resources  folder to support builds
+        public string serializedObjectPath = "SerializedFields"; 
 
         // ******************************************************
         // ABSTRACT METHODS THAT VISUALISATIONS HAVE TO IMPLEMENT
@@ -168,8 +168,8 @@ namespace IATK
 
         private string ConfigurationFileName()
         {
-            string PathName = Application.dataPath + "/" + serializedObjectPath;
-            return PathName + "/" + visualisationReference.uid + ".json";
+            string PathName = Application.streamingAssetsPath + Path.DirectorySeparatorChar + serializedObjectPath;
+            return PathName + Path.DirectorySeparatorChar + visualisationReference.uid + ".json";
         }
 
         /// <summary>

--- a/Assets/IATK/Scripts/Controller/AbstractVisualisation.cs
+++ b/Assets/IATK/Scripts/Controller/AbstractVisualisation.cs
@@ -81,7 +81,7 @@ namespace IATK
         public CreationConfiguration creationConfiguration;
 
         [HideInInspector]
-        public string serializedObjectPath = "SerializedFields";
+        public string serializedObjectPath = "Resources/SerializedFields"; // moved to Resources  folder to support builds
 
         // ******************************************************
         // ABSTRACT METHODS THAT VISUALISATIONS HAVE TO IMPLEMENT

--- a/Assets/IATK/Scripts/Controller/Visualisation Util Classes/CreationConfiguration.cs
+++ b/Assets/IATK/Scripts/Controller/Visualisation Util Classes/CreationConfiguration.cs
@@ -81,15 +81,7 @@ namespace IATK {
 
         public void DeSerialize(string serializedObjectPath, CreationConfiguration cf)
         {
-#if UNITY_EDITOR
-            string text = File.ReadAllText(serializedObjectPath);
-#else
-            // in a build we load from resource asset
-            string text = Resources.Load<TextAsset>(serializedObjectPath).text;
-            Debug.Log("Loaded from resource (" + serializedObjectPath + "): " + (text.Length != 0));
-#endif
-
-            SerializableCreationConfiguration scc = JsonUtility.FromJson<SerializableCreationConfiguration>(text);
+            SerializableCreationConfiguration scc = JsonUtility.FromJson<SerializableCreationConfiguration>(File.ReadAllText(serializedObjectPath));
 
             cf.VisualisationType = (AbstractVisualisation.VisualisationTypes)System.Enum.Parse(typeof(AbstractVisualisation.VisualisationTypes), scc.VisualisationType);
 

--- a/Assets/IATK/Scripts/Controller/Visualisation Util Classes/CreationConfiguration.cs
+++ b/Assets/IATK/Scripts/Controller/Visualisation Util Classes/CreationConfiguration.cs
@@ -81,7 +81,15 @@ namespace IATK {
 
         public void DeSerialize(string serializedObjectPath, CreationConfiguration cf)
         {
-            SerializableCreationConfiguration scc = JsonUtility.FromJson<SerializableCreationConfiguration>(File.ReadAllText(serializedObjectPath));
+#if UNITY_EDITOR
+            string text = File.ReadAllText(serializedObjectPath);
+#else
+            // in a build we load from resource asset
+            string text = Resources.Load<TextAsset>(serializedObjectPath).text;
+            Debug.Log("Loaded from resource (" + serializedObjectPath + "): " + (text.Length != 0));
+#endif
+
+            SerializableCreationConfiguration scc = JsonUtility.FromJson<SerializableCreationConfiguration>(text);
 
             cf.VisualisationType = (AbstractVisualisation.VisualisationTypes)System.Enum.Parse(typeof(AbstractVisualisation.VisualisationTypes), scc.VisualisationType);
 

--- a/Assets/IATK/Scripts/Controller/Visualisation.cs
+++ b/Assets/IATK/Scripts/Controller/Visualisation.cs
@@ -342,7 +342,7 @@ namespace IATK
             }
 
             // load serialized view configuration from disk
-            if (File.Exists(ConfigurationFileName()) || Resources.Load(ConfigurationFileName()) != null)
+            if (File.Exists(ConfigurationFileName()))
             {
                 if (theVisualizationObject.creationConfiguration == null) theVisualizationObject.creationConfiguration = new CreationConfiguration();
                 if (!dataSource.IsLoaded) dataSource.load();
@@ -443,14 +443,8 @@ namespace IATK
 
         private string ConfigurationFileName()
         {
-#if UNITY_EDITOR
-            string PathName = Application.dataPath + "/" + theVisualizationObject.serializedObjectPath;
-            return PathName + "/" + uid + ".json";
-#else
-            // in a build we use resource loading, so don't need app path or extension
-            string PathName = theVisualizationObject.serializedObjectPath.Replace("Resources/", "");
-            return PathName + "/" + uid;
-#endif
+            string PathName = Application.streamingAssetsPath + Path.DirectorySeparatorChar + theVisualizationObject.serializedObjectPath;
+            return PathName + Path.DirectorySeparatorChar + uid + ".json";
         }
 
         //<summary>

--- a/Assets/IATK/Scripts/Model/CSVDataSource.cs
+++ b/Assets/IATK/Scripts/Model/CSVDataSource.cs
@@ -449,6 +449,15 @@ namespace IATK
             float minDimension = result.Min();
             float maxDimension = result.Max();
 
+            if (minDimension == maxDimension)
+            {
+                // where there are no distinct values, need the dimension to be distinct 
+                // otherwise lots of maths breaks with division by zero, etc.
+                // this is the most elegant hack I could think of, but should be fixed properly in future
+                minDimension -= 1.0f; 
+                maxDimension += 1.0f;
+            }
+
             DataSource.DimensionData.Metadata metadata = dimensionData[col].MetaData;
 
             metadata.minValue = minDimension;

--- a/Assets/IATK/Scripts/View/BigMesh.cs
+++ b/Assets/IATK/Scripts/View/BigMesh.cs
@@ -63,8 +63,19 @@ namespace IATK
 
         // PROPERTIES
 
-        public Material SharedMaterial {                              // The common material shared between all submeshes
-            get; private set;
+        [SerializeField] // needs to be serialized for build support
+        private Material sharedMaterial;
+
+        // The common material shared between all submeshes
+        public Material SharedMaterial {                              
+            get
+            {
+                return sharedMaterial;
+            }
+            private set
+            {
+                sharedMaterial = value;
+            }
         }
 
         // PUBLIC


### PR DESCRIPTION
These changes allow visualisations created in the editor to be manipulated in a build at runtime by correctly serialising and deserialising state between all three modes: edit, play and build.

To summarise the changes in this pull request:

- serialised configuration now saved to StreamingAssets/SerializedFields so they can be accessed in a build via file io
- shared material in BigMesh implemented as read-only property via private serialized field to support serialisation in Unity
- changed RuntimeEditorLoadAndSaveConfiguration method in Visualisation to allow reloading config in all three modes: edit/play/build 
- bug fix to support correct view list + BigMesh reconstitution in Visualisation

Tested using Unity 2019.2.17f1